### PR TITLE
Fix: Zero in condition

### DIFF
--- a/src/CondParse/Lexer.php
+++ b/src/CondParse/Lexer.php
@@ -97,7 +97,7 @@ class Lexer implements LexerInterface
     protected function extractMatch($matches)
     {
         foreach ($matches as $key => $value) {
-            if (is_string($key) && !empty($value)) {
+            if (is_string($key) && $value !== '') {
                 return [$value, $key];
             }
         }


### PR DESCRIPTION
- changed condition `!empty($value)` to `$value !== '''`. PHP generated offset Notice if I try parse condition string with zero (e.g. `1 && 0`) because string '0' is evaluated by function empty() as TRUE

btw.  thank you very much for this package 👍 🙂 